### PR TITLE
Configure for remote build: update .funcignore and azure.yaml

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -1,10 +1,9 @@
 *.js.map
-*.ts
 .git*
 .vscode
 __azurite_db*__.json
 __blobstorage__
 __queuestorage__
+node_modules/
 local.settings.json
 test
-tsconfig.json

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,3 +8,4 @@ services:
     project: .
     language: js
     host: function
+    remoteBuild: true


### PR DESCRIPTION
## Summary

Configures the project for remote build when deploying with `azd`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under the `api` service
- **.funcignore**: Removed `*.ts` and `tsconfig.json` entries (not needed for JS projects), added `node_modules` to ensure dependencies are installed during remote build

## Context

When deploying with `azd`, remote build is used. The `.funcignore` should exclude `node_modules` so that dependencies are installed on the server during deployment rather than being uploaded from the local machine. This avoids issues with platform-specific native binaries and reduces deployment package size.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.